### PR TITLE
Landscape to Portrait switch issue when video completed

### DIFF
--- a/exoplayerview/src/main/java/com/jarvanmo/exoplayerview/ui/ExoVideoPlaybackControlView.java
+++ b/exoplayerview/src/main/java/com/jarvanmo/exoplayerview/ui/ExoVideoPlaybackControlView.java
@@ -824,8 +824,9 @@ public class ExoVideoPlaybackControlView extends FrameLayout {
                 visibilityListener.onVisibilityChange(getVisibility());
             }
 
-            changeSystemUiVisibilityPortrait();
-
+            if (portrait) {
+                changeSystemUiVisibilityPortrait();
+            }
 
             updateAll();
             requestPlayPauseFocus();


### PR DESCRIPTION
This PR fixes the issue that occurs when the video is playing in landscape mode and it has ended but switch to portrait doesn't work.